### PR TITLE
Add HF integration

### DIFF
--- a/NeuFlow/neuflow.py
+++ b/NeuFlow/neuflow.py
@@ -7,13 +7,14 @@ from NeuFlow import matching
 from NeuFlow import corr
 from NeuFlow import refine
 from NeuFlow import upsample
-from NeuFlow import utils
 from NeuFlow import config
 
-import time
+from huggingface_hub import PyTorchModelHubMixin
 
 
-class NeuFlow(torch.nn.Module):
+class NeuFlow(torch.nn.Module,
+              PyTorchModelHubMixin,
+              repo_url="https://github.com/neufieldrobotics/NeuFlow_v2", license="apache-2.0", pipeline_tag="image-to-image"):
     def __init__(self):
         super(NeuFlow, self).__init__()
 


### PR DESCRIPTION
Hi,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the model using `from_pretrained` (and push it using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis, and perhaps most importantly, leverage `safetensors` for the weights in favor of pickle. 

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from NeuFlow.neuflow import NeuFlow

# instantiate model
model = NeuFlow()

# equip model with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("your-hf-org/neuflow-v2")

# reload
model = NeuFlow.from_pretrained("your-hf-org/neuflow-v2")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub, and they can discover it when filtering https://huggingface.co/models.

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub :)